### PR TITLE
fix: tag filter ui for tasks

### DIFF
--- a/assets/ts/components/tag_filter.ts
+++ b/assets/ts/components/tag_filter.ts
@@ -1,0 +1,54 @@
+import TagList from "./tag_index";
+import AutocompleteTags from "./autocomplete_tags";
+import { ApiTag, ApiTagFromName } from "../core/api/tag_api";
+import { AutocompleteEnterPressedEvent } from "./autocomplete";
+
+export class TagFilter {
+    private tagList: TagList;
+    private autocompleteTags: AutocompleteTags;
+
+    constructor($container: JQuery) {
+        this.tagList = new TagList($container.find('.js-tag-list'));
+        this.autocompleteTags = new AutocompleteTags($container.find('.js-autocomplete-tags'));
+
+        this.autocompleteTags.itemSelected.addObserver((apiTag: ApiTag) => {
+            this.addTag(apiTag);
+        })
+
+        this.autocompleteTags.enterPressed.addObserver((event: AutocompleteEnterPressedEvent<ApiTag>) => {
+            if (event.data) {
+                this.addTag(event.data);
+            } else {
+                this.addTag(event.query);
+            }
+        })
+
+        $container.find('.js-autocomplete-tags .js-add').on('click', event => {
+            const query = this.autocompleteTags.getQuery();
+
+            this.addTag(query);
+        })
+
+        const $realTagInput = $container.find('.js-real-tag-input');
+        this.tagList.tagsChanged.addObserver(() => {
+            this.autocompleteTags.setTagNames(this.tagList.getTagNames());
+            $realTagInput.val(this.tagList.getTagNamesCommaSeparated());
+        });
+    }
+
+    private addTag(tag: ApiTag|string) {
+        if (typeof tag === 'string') {
+            tag = ApiTagFromName(tag);
+        }
+
+        this.tagList.add(tag);
+
+        this.autocompleteTags.clear();
+
+        setTimeout(() => {
+            this.autocompleteTags.positionSearchContent();
+        }, 10);
+    }
+}
+
+

--- a/assets/ts/core/api/tag_api.ts
+++ b/assets/ts/core/api/tag_api.ts
@@ -5,6 +5,13 @@ export interface ApiTag {
     color: string;
 }
 
+export function ApiTagFromName(name: string): ApiTag {
+    return {
+        name,
+        color: '#5d5d5d'
+    };
+}
+
 export class TagApi {
     public static index(searchTerm: string, excludeTags: Array<string> = [] ) {
         let url = `/json/tag?searchTerm=${searchTerm}`;

--- a/assets/ts/note_index.ts
+++ b/assets/ts/note_index.ts
@@ -4,15 +4,9 @@ import $ from 'jquery';
 import Observable from "./components/observable";
 import { ApiNote, CreateNoteOptions, NoteApi } from "./core/api/note_api";
 import Flashes from "./components/flashes";
-import { ApiStatistic, CreateStatisticOptions, StatisticApi } from "./core/api/statistic_api";
 import { ApiErrorResponse } from "./core/api/api";
 import { createTagsView } from "./components/tags";
-import AutocompleteTags from "./components/autocomplete_tags";
-import AutocompleteTask from "./components/autocomplete_task";
-import { ApiTask } from "./core/api/task_api";
-import { AutocompleteEnterPressedEvent } from "./components/autocomplete";
-import TagList from "./components/tag_index";
-import { ApiTag } from "./core/api/tag_api";
+import { TagFilter } from "./components/tag_filter";
 
 class CreateNoteForm {
     private $title: JQuery;
@@ -59,49 +53,12 @@ class CreateNoteForm {
 class NoteListFilter {
     private $element: JQuery;
     private flashes: Flashes;
-    private autocompleteTags: AutocompleteTags;
+    private tagFilter: TagFilter;
 
     constructor($element: JQuery, flashes: Flashes) {
         this.$element = $element;
         this.flashes = flashes;
-
-        this.setUpTagFilter();
-    }
-
-    private setUpTagFilter() {
-        const $tagListFilter = this.$element.find('.js-tags-filter');
-        const tagList = new TagList($tagListFilter.find('.js-tag-list'));
-        this.autocompleteTags = new AutocompleteTags($tagListFilter.find('.js-autocomplete-tags'));
-
-        this.autocompleteTags.itemSelected.addObserver((apiTag: ApiTag) => {
-            tagList.add(apiTag);
-            setTimeout(() => {
-                this.autocompleteTags.positionSearchContent();
-            }, 10);
-        })
-
-        this.autocompleteTags.enterPressed.addObserver((event: AutocompleteEnterPressedEvent<ApiTag>) => {
-            if (event.data) {
-                tagList.add(event.data);
-            } else {
-                tagList.add({
-                    name: event.query,
-                    color: '#5d5d5d'
-                });
-            }
-
-            this.autocompleteTags.clear();
-
-            setTimeout(() => {
-                this.autocompleteTags.positionSearchContent();
-            }, 10);
-        })
-
-        const $realTagInput = this.$element.find('.js-real-tag-input');
-        tagList.tagsChanged.addObserver(() => {
-            this.autocompleteTags.setTagNames(tagList.getTagNames());
-            $realTagInput.val(tagList.getTagNamesCommaSeparated());
-        });
+        this.tagFilter = new TagFilter($element);
     }
 }
 

--- a/assets/ts/task_index.ts
+++ b/assets/ts/task_index.ts
@@ -7,6 +7,8 @@ import LoadingButton from "./components/loading_button";
 import TimeTrackerRoutes from "./core/routes";
 import Observable from "./components/observable";
 import { createTagsView } from "./components/tags";
+import Flashes from "./components/flashes";
+import { TagFilter } from "./components/tag_filter";
 
 class TaskTable {
     private $container: JQuery;
@@ -134,10 +136,25 @@ class CreateTaskForm {
     }
 }
 
+class TaskListFilter {
+    private $element: JQuery;
+    private flashes: Flashes;
+    private tagFilter: TagFilter;
+
+    constructor($element: JQuery, flashes: Flashes) {
+        this.$element = $element;
+        this.flashes = flashes;
+        this.tagFilter = new TagFilter($element);
+    }
+}
+
 $(document).ready(() => {
     const $data = $('.js-data');
     const showCompleted = $data.data('show-completed');
     const nameSort = $data.data('name-sort');
+
+    const flashes = new Flashes($('#fixed-flash-messages'));
+    const filter = new TaskListFilter($('.filter'), flashes);
 
     const routes = new TimeTrackerRoutes();
     routes.addTemplateFromJoined($data.data('route-time-entry-index'));

--- a/assets/ts/time_entry_index.ts
+++ b/assets/ts/time_entry_index.ts
@@ -23,10 +23,10 @@ import { EditDateTime } from "./components/edit_date_time";
 import { TimeEntryTaskAssigner } from "./components/time_entry_task_assigner";
 import { TagAssigner } from "./components/tag_assigner";
 import TimerView from "./components/timer";
-import AutocompleteTags from "./components/autocomplete_tags";
 import AutocompleteTask from "./components/autocomplete_task";
 import MarkdownView from "./components/markdown_view";
 import { AutocompleteEnterPressedEvent } from "./components/autocomplete";
+import { TagFilter } from "./components/tag_filter";
 
 interface TimeEntryActionDelegate {
     continue(timeEntryId: string): Promise<any>;
@@ -635,14 +635,14 @@ class TimeEntryList {
 class TimeEntryListFilter {
     private $element: JQuery;
     private flashes: Flashes;
-    private autocompleteTags: AutocompleteTags;
+    private tagFilter: TagFilter;
 
     constructor($element: JQuery, flashes: Flashes) {
         this.$element = $element;
         this.flashes = flashes;
 
         this.setUpTaskFilter();
-        this.setUpTagFilter();
+        this.tagFilter = new TagFilter($element);
     }
 
     private setUpTaskFilter() {
@@ -662,10 +662,6 @@ class TimeEntryListFilter {
                 autocompleteTask.clearSearchContent();
                 $realTaskInput.val(event.data.id);
             }
-
-            setTimeout(() => {
-                this.autocompleteTags.positionSearchContent();
-            }, 10);
         })
 
         autocompleteTask.inputChange.addObserver(() => {
@@ -675,40 +671,6 @@ class TimeEntryListFilter {
         autocompleteTask.inputClear.addObserver(() => {
             $realTaskInput.val('');
         })
-    }
-
-    private setUpTagFilter() {
-        const $tagListFilter = this.$element.find('.js-tags-filter');
-        const tagList = new TagList($tagListFilter.find('.js-tag-list'));
-        this.autocompleteTags = new AutocompleteTags($tagListFilter.find('.js-autocomplete-tags'));
-
-        this.autocompleteTags.itemSelected.addObserver((apiTag: ApiTag) => {
-            tagList.add(apiTag);
-            setTimeout(() => {
-                this.autocompleteTags.positionSearchContent();
-            }, 10);
-        })
-
-        this.autocompleteTags.enterPressed.addObserver((event: AutocompleteEnterPressedEvent<ApiTag>) => {
-            if (event.data) {
-                tagList.add(event.data);
-            } else {
-                tagList.add({
-                    name: event.query,
-                    color: '#5d5d5d'
-                });
-            }
-
-            setTimeout(() => {
-                this.autocompleteTags.positionSearchContent();
-            }, 10);
-        })
-
-        const $realTagInput = this.$element.find('.js-real-tag-input');
-        tagList.tagsChanged.addObserver(() => {
-            this.autocompleteTags.setTagNames(tagList.getTagNames());
-            $realTagInput.val(tagList.getTagNamesCommaSeparated());
-        });
     }
 }
 

--- a/src/Controller/ApiTaskController.php
+++ b/src/Controller/ApiTaskController.php
@@ -51,7 +51,6 @@ class ApiTaskController extends BaseController
             [
                 'csrf_protection' => false,
                 'method' => 'GET',
-                'allow_extra_fields' => true
             ]
         );
 

--- a/src/Controller/ApiTimeEntryController.php
+++ b/src/Controller/ApiTimeEntryController.php
@@ -69,7 +69,6 @@ class ApiTimeEntryController extends BaseController
                 'timezone' => $this->getUser()->getTimezone(),
                 'csrf_protection' => false,
                 'method' => 'GET',
-                'allow_extra_fields' => true
             ]
         );
 

--- a/src/Controller/NoteController.php
+++ b/src/Controller/NoteController.php
@@ -37,7 +37,6 @@ class NoteController extends BaseController
             [
                 'csrf_protection' => false,
                 'method' => 'GET',
-                'allow_extra_fields' => true
             ]
         );
 

--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -44,7 +44,6 @@ class TaskController extends BaseController
             [
                 'csrf_protection' => false,
                 'method' => 'GET',
-                'allow_extra_fields' => true
             ]
         );
 

--- a/src/Controller/TimeEntryController.php
+++ b/src/Controller/TimeEntryController.php
@@ -50,7 +50,6 @@ class TimeEntryController extends BaseController
                 'timezone' => $this->getUser()->getTimezone(),
                 'csrf_protection' => false,
                 'method' => 'GET',
-                'allow_extra_fields' => true
             ]
         );
 

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -15,6 +15,7 @@ use DateTimeZone;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use InvalidArgumentException;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -72,6 +73,11 @@ class Task
      */
     private User $assignedTo;
 
+    public static function canonicalizeName(string $name): string
+    {
+        return trim(strtolower($name));
+    }
+
     public function __construct(User $assignedTo, string $name)
     {
         $this->id = Uuid::uuid4();
@@ -84,11 +90,6 @@ class Task
         $this->completedAt = null;
         $this->priority = 0;
         $this->tagLinks = new ArrayCollection();
-    }
-
-    private function canonicalizeName(string $name): string
-    {
-        return trim(strtolower($name));
     }
 
     public function getName(): string
@@ -105,7 +106,7 @@ class Task
     {
         $this->name = $name;
 
-        $this->canonicalName = $this->canonicalizeName($name);
+        $this->canonicalName = self::canonicalizeName($name);
 
         if (strlen($this->canonicalName) === 0) {
             throw new InvalidArgumentException('Name can not be blank once whitespace is removed.');

--- a/src/Form/Model/TaskListFilterModel.php
+++ b/src/Form/Model/TaskListFilterModel.php
@@ -7,14 +7,14 @@ namespace App\Form\Model;
 class TaskListFilterModel
 {
     private bool $showCompleted;
-    private ?string $name;
-    private ?string $description;
+    private ?string $content;
+    private ?string $tags;
 
     public function __construct()
     {
         $this->showCompleted = false;
-        $this->name = null;
-        $this->description = null;
+        $this->content = null;
+        $this->tags = null;
     }
 
     public function getShowCompleted(): bool
@@ -28,35 +28,54 @@ class TaskListFilterModel
         return $this;
     }
 
-    public function getName(): ?string
+    public function getContent(): ?string
     {
-        return $this->name;
+        return $this->content;
     }
 
-    public function hasName(): bool
+    public function hasContent(): bool
     {
-        return !is_null($this->name);
+        return !is_null($this->content);
     }
 
-    public function setName(?string $name): self
+    public function setContent(?string $content): self
     {
-        $this->name = $name;
+        $this->content = $content;
         return $this;
     }
 
-    public function getDescription(): ?string
+    public function getTags(): string
     {
-        return $this->description;
+        return $this->tags;
     }
 
-    public function hasDescription(): bool
+    public function hasTags(): bool
     {
-        return !is_null($this->description);
+        return !is_null($this->tags) && $this->tags !== '';
     }
 
-    public function setDescription(?string $description): self
+    /**
+     * @return string[]
+     */
+    public function getTagsArray(): array
     {
-        $this->description = $description;
+        if (is_null($this->tags) || $this->tags === '') {
+            return [];
+        }
+
+        $results = explode(',', $this->tags);
+
+        $results = array_map(
+            fn ($tagRaw) => str_replace(' ', '', $tagRaw),
+            $results
+        );
+
+        return $results;
+    }
+
+    public function setTags(?string $tags): self
+    {
+        $this->tags = $tags;
         return $this;
     }
 }

--- a/src/Form/TaskListFilterFormType.php
+++ b/src/Form/TaskListFilterFormType.php
@@ -19,19 +19,17 @@ class TaskListFilterFormType extends AbstractType
             ->add('showCompleted', CheckboxType::class, [
                 'required' => false
             ])
-            ->add('description', TextType::class, [
+            ->add('content', TextType::class, [
                 'required' => false
             ])
-            ->add('name', TextType::class, [
-                'required' => false
+            ->add('tags', TextType::class, [
+                'required' => false,
             ])
         ;
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
-                                   'data_class' => TaskListFilterModel::class,
-                               ]);
+        $resolver->setDefaults(['data_class' => TaskListFilterModel::class]);
     }
 }

--- a/templates/components/autocomplete.html.twig
+++ b/templates/components/autocomplete.html.twig
@@ -22,7 +22,6 @@
                 type="text"
                 class="js-input form-control unset-height"
                 placeholder="{{ _attr.placeholder }}"
-                name="{{ name }}-name"
                 value="{{ _attr.value }}"
                 autocomplete="off">
         <button type="button" class="clear js-clear btn btn-sm"><i class="fas fa-times"></i></button>

--- a/templates/task/index.html.twig
+++ b/templates/task/index.html.twig
@@ -1,5 +1,6 @@
 {% extends 'sidebar.html.twig' %}
 {% import 'time/partials.html.twig' as time %}
+{% import 'components/autocomplete.html.twig' as autocomplete %}
 
 {% block content_class %}w-100{% endblock %}
 
@@ -24,7 +25,17 @@
         <div class="filter table-filter mb-3">
             <div class="filter-title">Filter</div>
             {{ form_start(filterForm) }}
-            {{ form_widget(filterForm) }}
+            {{ form_row(filterForm.showCompleted) }}
+            {{ form_row(filterForm.content) }}
+
+            {{ form_label(filterForm.tags) }}
+            <div class="js-tags-filter d-flex align-items-center mb-2">
+                {{ form_widget(filterForm.tags, {attr: {class: 'js-real-tag-input d-none'}}) }}
+                <div class="js-tags tag-list js-tag-list many-rows" data-initial-tags-name="{{ app.request.query.get('tags') }}"></div>
+
+                {{ autocomplete.add('tags', { button: { class: 'bg-weak-white btn-outline-primary'} }) }}
+            </div>
+
             <button type="submit" class="btn btn-primary">Search</button>
             {{ form_end(filterForm) }}
         </div>
@@ -56,7 +67,13 @@
         <form class="js-task-create form-row">
             <div class="col">
                 <label class="sr-only" for="create-task-name">New task name</label>
-                <input type="text" id="create-task-name" class="form-control js-name" placeholder="What do you want to achieve?" />
+                <input
+                        id="create-task-name"
+                        type="text"
+                        class="form-control js-name"
+                        autocomplete="off"
+                        placeholder="What do you want to achieve?"
+                />
             </div>
             <div class="col-auto">
                 <button type="button" class="btn btn-primary js-button js-loading-button">


### PR DESCRIPTION
* Fixes an issue where tag filters did not do anything when the add button was clicked.
* Centralized TagFilter to it's own class
* Tasks can now be searched by both name and description in a single `content` field
* Remove allowing extra fields for filters. This was due to search, which was submitted, even though it shouldn't have been
* Remove html autocomplete from task input on task index page, as it can be annoying with the js autocomplete already there.

Closes #97